### PR TITLE
feat: Reload postfix config without terminating connections

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,6 +4,7 @@ class postfix::params {
   $conf_dir     = '/etc/postfix'
   $package_name = 'postfix'
   $service_name = 'postfix'
+  $service_reload_command = '/usr/bin/systemctl reload postfix.service'
 
   case $::osfamily {
     'RedHat': {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -6,5 +6,6 @@ class postfix::service {
     enable     => true,
     hasstatus  => true,
     hasrestart => true,
+    restart    => $::postfix::service_reload_command,
   }
 }


### PR DESCRIPTION
As a system administrator I would like to apply configuration changed for postfix by reloading it.

Before this PR, puppet restarts the postfix service which leads to terminated connections for clients on config changes.

Only in rare situations a restart of postfix is required to make changes effectiv: http://www.postfix.org/postconf.5.html

Changing the restart command to reload is also non-breaking as puppet starts a stopped service on notification by other/depending resources.

The default restart command is using systemd as it's the default service management on modern systems.
This may be has to be reworked when rebasing babiel/puppet-postfix on bodgit/puppet-postfix to bring this improvement to upstream, but at the moment both projects diverge a lot which will require additional work in the future.